### PR TITLE
fix: handle jwt error as unauthorized error

### DIFF
--- a/internal/auth/jwt_hs256.go
+++ b/internal/auth/jwt_hs256.go
@@ -1,9 +1,11 @@
 package auth
 
 import (
+	"errors"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/itsLeonB/time-tracker/internal/apperror"
 	"github.com/itsLeonB/time-tracker/internal/config"
 	"github.com/rotisserie/eris"
 )
@@ -55,6 +57,10 @@ func (j *jwtHS256) VerifyToken(tokenstr string) (*JWTClaims, error) {
 		jwt.WithExpirationRequired(),
 	)
 	if err != nil {
+		if errors.Is(err, jwt.ErrTokenExpired) {
+			return nil, apperror.UnauthorizedError(err)
+		}
+
 		return nil, eris.Wrap(err, "error parsing token")
 	}
 

--- a/internal/delivery/http/middleware/error_middleware.go
+++ b/internal/delivery/http/middleware/error_middleware.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"log"
+
 	"github.com/gin-gonic/gin"
 	"github.com/itsLeonB/time-tracker/internal/apperror"
 	strategy "github.com/itsLeonB/time-tracker/internal/delivery/http/middleware/strategy/error"
@@ -16,6 +18,7 @@ func HandleError(errorStrategyMap *strategy.ErrorStrategyMap) gin.HandlerFunc {
 			handledError, ok := err.Err.(*apperror.AppError)
 			if !ok {
 				handledError = eris.Unwrap(err.Err)
+				log.Println(eris.ToString(err.Err, true))
 			}
 
 			errorStrategy := errorStrategyMap.DetermineStrategy(handledError)


### PR DESCRIPTION
This resolves #31 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for expired tokens during verification, providing more specific error responses.
	- Improved logging for unhandled errors in the error middleware, aiding in better error tracking.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->