### PR TITLE
feat(auth): bump JWT token duration

### DIFF
--- a/internal/config/auth_config.go
+++ b/internal/config/auth_config.go
@@ -17,7 +17,7 @@ type Auth struct {
 func loadAuthConfig() *Auth {
 	return &Auth{
 		SecretKey:      os.Getenv("SECRET_KEY"),
-		TokenDuration:  5 * time.Hour,
+		TokenDuration:  9 * time.Hour,
 		CookieDuration: 24 * time.Hour,
 		Issuer:         os.Getenv("APP_NAME"),
 		URL:            fmt.Sprintf("%s:%s", os.Getenv("APP_HOST"), os.Getenv("APP_PORT")),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Extended session duration from 5 hours to 9 hours, allowing for longer active user sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->